### PR TITLE
Add inline italic element extension

### DIFF
--- a/core/core.rng
+++ b/core/core.rng
@@ -4,5 +4,6 @@
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 
     <include href="attributes/lang.rng"/>
+    <include href="inline.rng"/>
 
 </grammar>

--- a/core/inline.rng
+++ b/core/inline.rng
@@ -12,7 +12,12 @@
     </define>
 
     <define name="libero.inline.full.content">
-        <text/>
+
+        <choice>
+            <ref name="libero.inline.full.formatting"/>
+            <text/>
+        </choice>
+
     </define>
 
     <define name="libero.inline.limited">
@@ -24,7 +29,28 @@
     </define>
 
     <define name="libero.inline.limited.content">
-        <text/>
+
+        <choice>
+            <ref name="libero.inline.limited.formatting"/>
+            <text/>
+        </choice>
+
+    </define>
+
+    <define name="libero.inline.full.formatting">
+        <ref name="libero.inline.full.highlighting"/>
+    </define>
+
+    <define name="libero.inline.limited.formatting">
+        <ref name="libero.inline.limited.highlighting"/>
+    </define>
+
+    <define name="libero.inline.full.highlighting">
+        <empty/>
+    </define>
+
+    <define name="libero.inline.limited.highlighting">
+        <empty/>
     </define>
 
 </grammar>

--- a/core/inline.rng
+++ b/core/inline.rng
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <define name="libero.inline.full">
+
+        <oneOrMore>
+            <ref name="libero.inline.full.content"/>
+        </oneOrMore>
+
+    </define>
+
+    <define name="libero.inline.full.content">
+        <text/>
+    </define>
+
+    <define name="libero.inline.limited">
+
+        <oneOrMore>
+            <ref name="libero.inline.limited.content"/>
+        </oneOrMore>
+
+    </define>
+
+    <define name="libero.inline.limited.content">
+        <text/>
+    </define>
+
+</grammar>

--- a/extensions/inline/italic.rng
+++ b/extensions/inline/italic.rng
@@ -3,11 +3,11 @@
 <grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 
-    <define name="libero.inline.full.content" combine="choice">
+    <define name="libero.inline.full.highlighting" combine="choice">
         <ref name="libero.italic.full"/>
     </define>
 
-    <define name="libero.inline.limited.content" combine="choice">
+    <define name="libero.inline.limited.highlighting" combine="choice">
         <ref name="libero.italic.limited"/>
     </define>
 

--- a/extensions/inline/italic.rng
+++ b/extensions/inline/italic.rng
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <define name="libero.inline.full.content" combine="choice">
+        <ref name="libero.italic.full"/>
+    </define>
+
+    <define name="libero.inline.limited.content" combine="choice">
+        <ref name="libero.italic.limited"/>
+    </define>
+
+    <define name="libero.italic.full">
+
+        <element name="italic">
+            <ref name="libero.italic.full.attributes"/>
+            <ref name="libero.italic.full.content"/>
+        </element>
+
+    </define>
+
+    <define name="libero.italic.limited">
+
+        <element name="italic">
+            <ref name="libero.italic.limited.attributes"/>
+            <ref name="libero.italic.limited.content"/>
+        </element>
+
+    </define>
+
+    <define name="libero.italic.full.attributes">
+        <empty/>
+    </define>
+
+    <define name="libero.italic.full.content">
+        <ref name="libero.inline.full"/>
+    </define>
+
+    <define name="libero.italic.limited.attributes">
+        <empty/>
+    </define>
+
+    <define name="libero.italic.limited.content">
+        <ref name="libero.inline.limited"/>
+    </define>
+
+</grammar>

--- a/tests/extensions/inline/italic/full/basic.rng
+++ b/tests/extensions/inline/italic/full/basic.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.full"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/full/custom-attribute.rng
+++ b/tests/extensions/inline/italic/full/custom-attribute.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng">
+
+        <define name="libero.italic.full.attributes">
+
+            <attribute name="key" ns="http://libero.pub/test">
+                <text/>
+            </attribute>
+
+        </define>
+
+    </include>
+
+    <start>
+        <ref name="libero.italic.full"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/full/custom-content.rng
+++ b/tests/extensions/inline/italic/full/custom-content.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng">
+
+        <define name="libero.italic.full.content">
+
+            <element name="replacement">
+                <text/>
+            </element>
+
+        </define>
+
+    </include>
+
+    <start>
+        <ref name="libero.italic.full"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/full/extra-attribute.rng
+++ b/tests/extensions/inline/italic/full/extra-attribute.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.full"/>
+    </start>
+
+    <define name="libero.italic.full.attributes" combine="interleave">
+
+        <attribute name="key" ns="http://libero.pub/test">
+            <text/>
+        </attribute>
+
+    </define>
+
+</grammar>

--- a/tests/extensions/inline/italic/full/extra-content.rng
+++ b/tests/extensions/inline/italic/full/extra-content.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.full"/>
+    </start>
+    
+    <define name="libero.inline.full.content" combine="choice">
+        
+        <element name="content">
+            <text/>
+        </element>
+        
+    </define>
+    
+</grammar>

--- a/tests/extensions/inline/italic/full/invalid/unknown-attribute.xml
+++ b/tests/extensions/inline/italic/full/invalid/unknown-attribute.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+<?expected-error line="5" message="Invalid attribute key for element italic"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/full/invalid/unknown-element.xml
+++ b/tests/extensions/inline/italic/full/invalid/unknown-element.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../basic.rng"?>
-<?expected-error line="6" message="Element italic has extra content: inline"?>
+<?expected-error line="5" message="Element italic has extra content: text"?>
 
 <italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
     foo <test:inline>bar</test:inline>

--- a/tests/extensions/inline/italic/full/invalid/unknown-element.xml
+++ b/tests/extensions/inline/italic/full/invalid/unknown-element.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+<?expected-error line="6" message="Element italic has extra content: inline"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    foo <test:inline>bar</test:inline>
+</italic>

--- a/tests/extensions/inline/italic/full/valid/basic.xml
+++ b/tests/extensions/inline/italic/full/valid/basic.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+
+<italic xmlns="http://libero.pub">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/full/valid/custom-attribute.xml
+++ b/tests/extensions/inline/italic/full/valid/custom-attribute.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../custom-attribute.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo <italic test:key="value">bar</italic>
+</italic>

--- a/tests/extensions/inline/italic/full/valid/custom-content.xml
+++ b/tests/extensions/inline/italic/full/valid/custom-content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../custom-content.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    <test:replacement>foo</test:replacement>
+</italic>

--- a/tests/extensions/inline/italic/full/valid/extra-attribute.xml
+++ b/tests/extensions/inline/italic/full/valid/extra-attribute.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../extra-attribute.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/full/valid/extra-content.xml
+++ b/tests/extensions/inline/italic/full/valid/extra-content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../extra-content.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    foo <test:content>bar</test:content> baz
+</italic>

--- a/tests/extensions/inline/italic/full/valid/nested.xml
+++ b/tests/extensions/inline/italic/full/valid/nested.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+
+<italic xmlns="http://libero.pub">
+    foo <italic>bar</italic>
+</italic>

--- a/tests/extensions/inline/italic/limited/basic.rng
+++ b/tests/extensions/inline/italic/limited/basic.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.limited"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/limited/custom-attribute.rng
+++ b/tests/extensions/inline/italic/limited/custom-attribute.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng">
+
+        <define name="libero.italic.limited.attributes">
+
+            <attribute name="key" ns="http://libero.pub/test">
+                <text/>
+            </attribute>
+
+        </define>
+
+    </include>
+
+    <start>
+        <ref name="libero.italic.limited"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/limited/custom-content.rng
+++ b/tests/extensions/inline/italic/limited/custom-content.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng">
+
+        <define name="libero.italic.limited.content">
+
+            <element name="replacement">
+                <text/>
+            </element>
+
+        </define>
+
+    </include>
+
+    <start>
+        <ref name="libero.italic.limited"/>
+    </start>
+
+</grammar>

--- a/tests/extensions/inline/italic/limited/extra-attribute.rng
+++ b/tests/extensions/inline/italic/limited/extra-attribute.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.limited"/>
+    </start>
+
+    <define name="libero.italic.limited.attributes" combine="interleave">
+
+        <attribute name="key" ns="http://libero.pub/test">
+            <text/>
+        </attribute>
+
+    </define>
+
+</grammar>

--- a/tests/extensions/inline/italic/limited/extra-content.rng
+++ b/tests/extensions/inline/italic/limited/extra-content.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub/test" xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="../../../../test-case.rng"/>
+
+    <include href="../../../../../extensions/inline/italic.rng"/>
+
+    <start>
+        <ref name="libero.italic.limited"/>
+    </start>
+    
+    <define name="libero.inline.limited.content" combine="choice">
+        
+        <element name="content">
+            <text/>
+        </element>
+        
+    </define>
+    
+</grammar>

--- a/tests/extensions/inline/italic/limited/invalid/unknown-attribute.xml
+++ b/tests/extensions/inline/italic/limited/invalid/unknown-attribute.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+<?expected-error line="5" message="Invalid attribute key for element italic"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/limited/invalid/unknown-element.xml
+++ b/tests/extensions/inline/italic/limited/invalid/unknown-element.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../basic.rng"?>
-<?expected-error line="6" message="Element italic has extra content: inline"?>
+<?expected-error line="5" message="Element italic has extra content: text"?>
 
 <italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
     foo <test:inline>bar</test:inline>

--- a/tests/extensions/inline/italic/limited/invalid/unknown-element.xml
+++ b/tests/extensions/inline/italic/limited/invalid/unknown-element.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+<?expected-error line="6" message="Element italic has extra content: inline"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    foo <test:inline>bar</test:inline>
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/basic.xml
+++ b/tests/extensions/inline/italic/limited/valid/basic.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+
+<italic xmlns="http://libero.pub">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/custom-attribute.xml
+++ b/tests/extensions/inline/italic/limited/valid/custom-attribute.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../custom-attribute.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo <italic test:key="value">bar</italic>
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/custom-content.xml
+++ b/tests/extensions/inline/italic/limited/valid/custom-content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../custom-content.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    <test:replacement>foo</test:replacement>
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/extra-attribute.xml
+++ b/tests/extensions/inline/italic/limited/valid/extra-attribute.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../extra-attribute.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test" test:key="value">
+    foo
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/extra-content.xml
+++ b/tests/extensions/inline/italic/limited/valid/extra-content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../extra-content.rng"?>
+
+<italic xmlns="http://libero.pub" xmlns:test="http://libero.pub/test">
+    foo <test:content>bar</test:content> baz
+</italic>

--- a/tests/extensions/inline/italic/limited/valid/nested.xml
+++ b/tests/extensions/inline/italic/limited/valid/nested.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../basic.rng"?>
+
+<italic xmlns="http://libero.pub">
+    foo <italic>bar</italic>
+</italic>


### PR DESCRIPTION
Adds an `<italic>` element.

(For semantic reasons this should not used, but in reality...)

Defines two ways of doing inline elements: `full` and `limited`. These produce the same results out of the box. `full` would be meant for things like paragraphs; `limited` for headings (though you could override these). Being separated allows you to block access to certain elements in the `limited ` context (eg not wanting links in headings), without running in to nesting problems (https://github.com/libero/schemas/pull/1#issuecomment-414706896).

This makes it more work and a bit more confusing (and doubles the number of test cases), but allows for more flexibility without having to go completely custom.