### PR TITLE
add setup.py to libero schemas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     url='http://github.com/libero/schemas',
     author='eLife sciences publications, ltd.',
     license='MIT',
+    packages=['api'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name='libero schemas',
+    version='0.1',
+    description='libero xml api schemas',
+    url='http://github.com/libero/schemas',
+    author='eLife sciences publications, ltd.',
+    license='MIT',
+    zip_safe=False
+)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1',
     description='libero xml api schemas',
     url='https://github.com/libero/schemas',
-    author='eLife sciences publications, ltd.',
+    maintainer='eLife Sciences Publications, Ltd',
     license='MIT',
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='libero schemas',
     version='0.1',
     description='libero xml api schemas',
-    url='http://github.com/libero/schemas',
+    url='https://github.com/libero/schemas',
     author='eLife sciences publications, ltd.',
     license='MIT',
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='libero schemas',
     version='0.1',
-    description='libero xml api schemas',
+    description='Libero data model schemas',
     url='https://github.com/libero/schemas',
     maintainer='eLife Sciences Publications, Ltd',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,5 @@ setup(
     url='http://github.com/libero/schemas',
     author='eLife sciences publications, ltd.',
     license='MIT',
-    packages=['api'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='libero schemas',
-    version='0.1',
+    version='0.0.1',
     description='Libero data model schemas',
     url='https://github.com/libero/schemas',
     maintainer='eLife Sciences Publications, Ltd',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    name='libero schemas',
+    name='libero-schemas',
     version='0.1',
     description='libero xml api schemas',
     url='http://github.com/libero/schemas',


### PR DESCRIPTION
This PR adds a `setup.py` file so it can be used as a python dependency.